### PR TITLE
Fix exemplar population

### DIFF
--- a/src/exemplars.js
+++ b/src/exemplars.js
@@ -104,11 +104,12 @@ exemplars
   - values are exemplar objects
 */
 
-const populateExemplars = (exemplars = {}) => {
+const populateExemplars = (param = {}, exemplars = {}) => {
   const denormalizedExemplars = {};
 
-  for (let i = 0; i < param.exemplarTypes.length; i += 1) {
-    const type = param.exemplarTypes[i];
+  const totalExemplarsCount = param.exemplarTypes.length * param.numExemplarsPerType;
+  for (let i = 0; i < totalExemplarsCount; i += 1) {
+    const type = param.exemplarTypes[i % param.exemplarTypes.length];
     if (!Array.isArray(denormalizedExemplars[type]))
       denormalizedExemplars[type] = [];
     denormalizedExemplars[type].push(new Exemplar(type));
@@ -123,7 +124,7 @@ const populateExemplars = (exemplars = {}) => {
   return exemplars;
 };
 
-const exemplars = populateExemplars();
+const exemplars = populateExemplars(param);
 
 const createExemplarCounts = curExemplars => {
   const exemplarCounts = {};
@@ -150,6 +151,7 @@ const normalizeExemplars = exmps => {
 };
 
 module.exports = {
+  Exemplar,
   normalizeExemplars,
   createExemplarCounts,
   populateExemplars,

--- a/src/exemplars.js
+++ b/src/exemplars.js
@@ -114,7 +114,6 @@ const populateExemplars = (param = {}, exemplars = {}) => {
       denormalizedExemplars[type] = [];
     denormalizedExemplars[type].push(new Exemplar(type));
   }
-
   Object.keys(denormalizedExemplars).forEach(type => {
     for (let i = 1; i <= denormalizedExemplars[type].length; i += 1) {
       exemplars[`${type}${i}`] = denormalizedExemplars[type][i - 1];

--- a/test/exemplars.test.js
+++ b/test/exemplars.test.js
@@ -1,22 +1,52 @@
 const { describe, it } = global;
 const assert = require("assert");
 const jsdom = require("jsdom");
+/* this weird stuff basically makes jsPsych testable in Node */
 const { JSDOM } = jsdom;
 const { window } = new JSDOM("<!DOCTYPE html><p>Hello world</p>");
 global.window = window;
 global.document = window.document;
 
-const { populateExemplars } = require("../src/exemplars");
-const { param } = require("../src/param");
+const { populateExemplars, Exemplar } = require("../src/exemplars");
+const paramSimple = {
+  exemplarTypes: ['NNN', 'BBB', 'NNB', 'NBB'],
+  numExemplarsPerType: 1
+}
+const exemplarsFromSimple = {
+  NNN1: new Exemplar('NNN'),
+  BBB1: new Exemplar('BBB'),
+  NNB1: new Exemplar('NNB'),
+  NBB1: new Exemplar('NBB'),
+}
+const paramLotsPerType = {
+  exemplarTypes: ['NNN', 'BBB'],
+  numExemplarsPerType: 17,
+}
 
-describe("Exemplar", () => {
-  it("generates the correct number of exemplars based on params", () => {
-    const exemplars = populateExemplars();
-    console.log(exemplars)
-    console.log(param)
+describe("Exemplars from simple param", () => {
+  it("generates the correct number of exemplars", () => {
+    const exemplars = populateExemplars(paramSimple);
     assert.equal(
       Object.keys(exemplars).length,
-      param.exemplarTypes.length * param.numExemplarsPerType
+      paramSimple.exemplarTypes.length * paramSimple.numExemplarsPerType
     );
+  });
+  it("generates the correct exemplar types", () => {
+    const exemplars = populateExemplars(paramSimple);
+    assert.deepEqual(
+      Object.keys(exemplars),
+      Object.keys(exemplarsFromSimple)
+    );
+  });
+  it("generates exemplars with information", () => {
+    const exemplars = populateExemplars(paramSimple);
+    assert.ok(exemplars.BBB1.getImages().length === 3);
+    assert.ok(exemplars.NNN1.getImages().length === 3);
+    assert.ok(exemplars.NNB1.getImages().length === 3);
+    assert.ok(exemplars.NBB1.getImages().length === 3);
+    assert.ok(exemplars.BBB1.type === 'BBB');
+    assert.ok(exemplars.NNN1.type === 'NNN');
+    assert.ok(exemplars.NNB1.type === 'NNB');
+    assert.ok(exemplars.NBB1.type === 'NBB');
   });
 });

--- a/test/exemplars.test.js
+++ b/test/exemplars.test.js
@@ -1,4 +1,4 @@
-const { describe, it } = global;
+const { describe, it, before } = global;
 const assert = require("assert");
 const jsdom = require("jsdom");
 /* this weird stuff basically makes jsPsych testable in Node */
@@ -20,26 +20,28 @@ const exemplarsFromSimple = {
 }
 const paramLotsPerType = {
   exemplarTypes: ['NNN', 'BBB'],
-  numExemplarsPerType: 17,
+  numExemplarsPerType: 13,
 }
 
 describe("Exemplars from simple param", () => {
+  let exemplars;
+  before(() => {
+    exemplars = populateExemplars(paramSimple);
+  });
+
   it("generates the correct number of exemplars", () => {
-    const exemplars = populateExemplars(paramSimple);
     assert.equal(
       Object.keys(exemplars).length,
       paramSimple.exemplarTypes.length * paramSimple.numExemplarsPerType
     );
   });
   it("generates the correct exemplar types", () => {
-    const exemplars = populateExemplars(paramSimple);
     assert.deepEqual(
       Object.keys(exemplars),
       Object.keys(exemplarsFromSimple)
     );
   });
   it("generates exemplars with information", () => {
-    const exemplars = populateExemplars(paramSimple);
     assert.ok(exemplars.BBB1.getImages().length === 3);
     assert.ok(exemplars.NNN1.getImages().length === 3);
     assert.ok(exemplars.NNB1.getImages().length === 3);
@@ -48,5 +50,28 @@ describe("Exemplars from simple param", () => {
     assert.ok(exemplars.NNN1.type === 'NNN');
     assert.ok(exemplars.NNB1.type === 'NNB');
     assert.ok(exemplars.NBB1.type === 'NBB');
+  });
+});
+
+describe('Exemplars from many-per-type param', () => {
+  let exemplars;
+  before(() => {
+    exemplars = populateExemplars(paramLotsPerType);
+  });
+  it("generates the correct amount of exemplars", () => {
+    assert.equal(Object.keys(exemplars).length, paramLotsPerType.numExemplarsPerType * 2);
+  });
+  it("generates the correct exemplar types", () => {
+    for (let i = 1; i < paramLotsPerType.numExemplarsPerType; i += 1) {
+      assert(Object.keys(exemplars).includes(`NNN${i}`))
+    }
+    for (let i = 1; i < paramLotsPerType.numExemplarsPerType; i += 1) {
+      assert(Object.keys(exemplars).includes(`BBB${i}`))
+    }
+  });
+  it("generates exemplars with information", () => {
+    for (let exemplar of Object.values(exemplars)) {
+      assert.equal(exemplar.getImages().length, 3);
+    }
   });
 });


### PR DESCRIPTION
This PR fixes the small exemplar population bug I described to you, and writes more tests to catch these sorts of things. It also adds a way to mock the `param` object for testing.