### PR TITLE
Add commit hash to jspsych dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Psychology experiment designed to test the effects of the valence of an image on the ability to recognize image patterns.",
   "private": true,
   "dependencies": {
-    "jspsych": "git+https://git@github.com/sandboxneu/jsPsych.git"
+    "jspsych": "git+https://git@github.com/sandboxneu/jsPsych.git#1b326d2"
   },
   "devDependencies": {
     "eslint": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2622,9 +2622,9 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-"jspsych@git+https://git@github.com/sandboxneu/jsPsych.git":
+"jspsych@git+https://git@github.com/sandboxneu/jsPsych.git#1b326d2":
   version "6.0.0"
-  resolved "git+https://git@github.com/sandboxneu/jsPsych.git#a9261bf994a806aa253986da960ece4f21d685ae"
+  resolved "git+https://git@github.com/sandboxneu/jsPsych.git#1b326d263865a4cdbc6881d140bc3f474b8ba88d"
 
 killable@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR fixes the weird test bug. What happened was the `yarn.lock` stored the commit it had when I first added the jsPsych fork as a dependency. So, although I updated the fork locally and pushed that to Github, the changes weren't reflected in the predictive-affect repo. My local version was fine because it was using my local version of jsPsych. This specifies the commit where I modularized jsPsych fully in the package.json as a dependency.