### PR TITLE
Update param to live-load in

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <title>Predictive Affect</title>
     <meta charset="UTF-8">
+    <script src="./src/param.js"></script>
     <script src="./dist/experiment.js" type="module"></script>
     <link href="predictiveaffect.css" rel="stylesheet" type="text/css"></link>
   </head>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "webpack --mode=development",
     "build:prod": "webpack --mode=production",
     "start": "webpack-dev-server",
-    "test": "mocha",
+    "test": "cp ./src/param.js ./node_modules/param.js && mocha",
     "format": "prettier --write ./**/*.js",
     "lint": "eslint ./**/*.js",
     "postinstall": "[ -f src/param.js ] || cp src/param.example.js src/param.js"

--- a/src/exemplars.js
+++ b/src/exemplars.js
@@ -1,4 +1,4 @@
-const { param } = require("./param");
+const param = require("param");
 const { copyImage } = require("./utils/imageUtils");
 const {
   randomlyPickFromList,

--- a/src/experiment.js
+++ b/src/experiment.js
@@ -20,7 +20,8 @@ const {
 const {
   getFoil
 } = require("./foils");
-const { param } = require("./param");
+const param = require("param");
+
 const timeline = [];
 
 // BEGIN INSTRUCTIONS

--- a/src/foils.js
+++ b/src/foils.js
@@ -1,4 +1,4 @@
-const { param } = require("./param");
+const param = require("param");
 const { exemplars } = require("./exemplars");
 const {
   neuImages,

--- a/src/param.example.js
+++ b/src/param.example.js
@@ -41,18 +41,16 @@ param.foilTestedType = [
 ]; /* for every exemplar, whether the replaced image in the foil is the same affect as the image it replaces. */
 param.completionCode = Math.floor(Math.random() * 1000000000);
 
-if (param.foilTestedOn.length !== param.exemplarTypes.length * numExemplarsPerType) {
+if (param.foilTestedOn.length !== param.exemplarTypes.length * param.numExemplarsPerType) {
   throw new Error(
     "param.foilTestedOn and param.exemplarTypes match up by position, so they must be the same length."
   );
 }
 
-if (param.foilTestedOn.length !== param.exemplarTypes.length * numExemplarsPerType) {
+if (param.foilTestedOn.length !== param.exemplarTypes.length * param.numExemplarsPerType) {
   throw new Error(
     "param.foilTestedType and param.exemplarTypes match up by position, so they must be the same length."
   );
 }
 
-module.exports = {
-  param
-};
+module.exports = param;

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -1,5 +1,5 @@
 const jsPsych = require("jspsych");
-const { param } = require("../param");
+const param = require("param");
 
 // Utilities for use in the html scripts
 const neuImages = [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,5 +6,8 @@ module.exports = {
     filename: 'experiment.js',
     path: path.resolve(__dirname, 'dist')
   },
+  externals: {
+    param: "param",
+  },
   devtool: 'cheap-module-source-map'
 }


### PR DESCRIPTION
This PR updates the behavior of the app to live-load `param.js` into the application. It uses a small hack in the way `require` resolves module names to keep tests passing (seen in the `package.json` file).

How I should probably do it is to use Webpack on the tests to bundle everything, but I don't really want to go through that learning process right now so this is what I have.